### PR TITLE
feat: allow LogicalIdMapper to be applied to a Stage in a Pipeline

### DIFF
--- a/API.md
+++ b/API.md
@@ -38,6 +38,20 @@ Aspects.of(stack).add(new LogicalIdMapper({
 }));
 ```
 
+For cdk-pipeline stages:
+```typescript
+
+const stage = new Stage(this, 'MyPipelineStage');
+
+Aspects.of(stage).add(new LogicalIdMapper({
+  map: {
+    SomeTopicDB89918F: 'MyTopic', // rename the SomeTopicDB89918F logical ID to MyTopic
+  }
+}));
+
+pipeline.addStage(stage);
+```
+
 ## Contributions.
 
 If you have [Issues](https://github.com/mbonig/cdk-logical-id-mapper), [yo, I'll solve it](https://www.youtube.com/watch?v=rog8ou-ZepE).

--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ Aspects.of(stack).add(new LogicalIdMapper({
 }));
 ```
 
+For cdk-pipeline stages:
+```typescript
+
+const stage = new Stage(this, 'MyPipelineStage');
+
+Aspects.of(stage).add(new LogicalIdMapper({
+  map: {
+    SomeTopicDB89918F: 'MyTopic', // rename the SomeTopicDB89918F logical ID to MyTopic
+  }
+}));
+
+pipeline.addStage(stage);
+```
+
 ## Contributions.
 
 If you have [Issues](https://github.com/mbonig/cdk-logical-id-mapper), [yo, I'll solve it](https://www.youtube.com/watch?v=rog8ou-ZepE). 

--- a/src/LogicalIdMapper.ts
+++ b/src/LogicalIdMapper.ts
@@ -31,11 +31,16 @@ export class LogicalIdMapper implements IAspect {
   }
 
   visit(node: IConstruct): void {
-    const currentLogicalId = Stack.of(node).getLogicalId(node as CfnElement);
-    // is there a map for this logicalId?
-    if (!!this.props.map[currentLogicalId]) {
-      // if we're on a L1 resource, try to do the override directly
-      if ((node as CfnResource).overrideLogicalId) return (node as CfnResource).overrideLogicalId(this.props.map[currentLogicalId]);
+    try {
+      const currentLogicalId = Stack.of(node).getLogicalId(node as CfnElement);
+      // is there a map for this logicalId?
+      if (!!this.props.map[currentLogicalId]) {
+        // if we're on a L1 resource, try to do the override directly
+        if ((node as CfnResource).overrideLogicalId) return (node as CfnResource).overrideLogicalId(this.props.map[currentLogicalId]);
+      }
+    } catch {
+      // This construct is not in the scope of a Stack, maybe because the Aspect was applied to a Stage
+      return;
     }
   }
 }

--- a/src/LogicalIdMapper.ts
+++ b/src/LogicalIdMapper.ts
@@ -38,9 +38,14 @@ export class LogicalIdMapper implements IAspect {
         // if we're on a L1 resource, try to do the override directly
         if ((node as CfnResource).overrideLogicalId) return (node as CfnResource).overrideLogicalId(this.props.map[currentLogicalId]);
       }
-    } catch {
-      // This construct is not in the scope of a Stack, maybe because the Aspect was applied to a Stage
-      return;
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message.endsWith('should be created in the scope of a Stack, but no Stack found')) {
+          // This construct is not in the scope of a Stack, maybe because the Aspect was applied to a Stage
+          return;
+        }
+      }
+      throw error;
     }
   }
 }

--- a/test/LogicalIdMapper.test.ts
+++ b/test/LogicalIdMapper.test.ts
@@ -1,23 +1,48 @@
-import { App, Aspects, Stack } from 'aws-cdk-lib';
+import { App, Aspects, Stack, Stage } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { Topic } from 'aws-cdk-lib/aws-sns';
 import { LogicalIdMapper } from '../src';
 
 test('Maps Ids', () => {
-
   // arrange
   const app = new App();
   const stack = new Stack(app, 'TestStack');
   new Topic(stack, 'SomeTopic');
 
-  Aspects.of(stack).add(new LogicalIdMapper({
-    map: {
-      SomeTopicDB89918F: 'MyTopic',
-    },
-  }));
+  Aspects.of(stack).add(
+    new LogicalIdMapper({
+      map: {
+        SomeTopicDB89918F: 'MyTopic',
+      },
+    }),
+  );
 
   // act
   const template = Template.fromStack(stack);
+
+  // assert
+  const topics = template.findResources('AWS::SNS::Topic');
+  expect(Object.keys(topics)[0]).toEqual('MyTopic');
+});
+
+test('Maps Ids in Stage', () => {
+  // arrange
+  const app = new App();
+  const pipelineStack = new Stack(app, 'PipelineStack');
+  const stage = new Stage(pipelineStack, 'Stage');
+  const stageStack = new Stack(stage, 'StageStack');
+  new Topic(stageStack, 'SomeTopic');
+
+  Aspects.of(stage).add(
+    new LogicalIdMapper({
+      map: {
+        SomeTopicDB89918F: 'MyTopic',
+      },
+    }),
+  );
+
+  // act
+  const template = Template.fromStack(stageStack);
 
   // assert
   const topics = template.findResources('AWS::SNS::Topic');


### PR DESCRIPTION
I was trying to override logical ids for individual stages in a cdk-pipelines setup and wasn't able to apply the LogicalIdMapper Aspect to a stage.  It gave this error:
```
 Stage at 'PipelineStack/Stage' should be created in the scope of a Stack, but no Stack found
```
I believe this change should allow the Aspect to be used on a stage